### PR TITLE
Support variable-duration Opus packets in CAF packet tables

### DIFF
--- a/lib/models/caf_models.dart
+++ b/lib/models/caf_models.dart
@@ -256,18 +256,41 @@ class CAFStringsChunk {
 
 /// A class representing a packet table in a CAF file.
 class PacketTable {
-  PacketTable({required this.header, required this.entries});
+  PacketTable({
+    required this.header,
+    required this.entries,
+    this.frameEntries = const <int>[],
+  });
 
   /// The header of the packet table.
   final PacketTableHeader header;
 
-  /// The list of entries in the packet table.
+  /// The packet-size entries in the packet table.
   final List<int> entries;
+
+  /// The per-packet frame-count entries in the packet table.
+  final List<int> frameEntries;
 
   /// Encodes the packet table to a Uint8List.
   Uint8List encode() {
-    final List<Uint8List> encodedVarintEntriesChunks =
-        entries.map((int entry) => encodeVarint(entry)).toList();
+    final int packetCount = header.numberPackets;
+    if (entries.isNotEmpty && entries.length != packetCount) {
+      throw ArgumentError('Packet table entries must match numberPackets');
+    }
+    if (frameEntries.isNotEmpty && frameEntries.length != packetCount) {
+      throw ArgumentError(
+          'Packet table frame entries must match numberPackets');
+    }
+
+    final List<Uint8List> encodedVarintEntriesChunks = <Uint8List>[];
+    for (int i = 0; i < packetCount; i++) {
+      if (entries.isNotEmpty) {
+        encodedVarintEntriesChunks.add(encodeVarint(entries[i]));
+      }
+      if (frameEntries.isNotEmpty) {
+        encodedVarintEntriesChunks.add(encodeVarint(frameEntries[i]));
+      }
+    }
 
     int totalLength = 24;
     for (final Uint8List encodedChunk in encodedVarintEntriesChunks) {

--- a/lib/models/caf_models.dart
+++ b/lib/models/caf_models.dart
@@ -262,7 +262,7 @@ class PacketTable {
   final PacketTableHeader header;
 
   /// The list of entries in the packet table.
-  final Uint8List entries;
+  final List<int> entries;
 
   /// Encodes the packet table to a Uint8List.
   Uint8List encode() {
@@ -292,6 +292,10 @@ class PacketTable {
 
   /// Encodes an integer to `data` using variable-length encoding technique (varint) format.
   Uint8List encodeVarint(int value) {
+    if (value == 0) {
+      return Uint8List.fromList(<int>[0]);
+    }
+
     final List<int> bytes = <int>[];
     int cur = value;
     while (cur != 0) {

--- a/lib/models/ogg_models.dart
+++ b/lib/models/ogg_models.dart
@@ -17,6 +17,50 @@ const int pageHeaderLen = 27;
 /// Length of the ID page payload.
 const int idPagePayloadLength = 19;
 
+/// Opus granule positions and trim values are always counted at 48 kHz.
+const int opusFixedSampleRate = 48000;
+
+/// Returns the number of decoded PCM samples contributed by an Opus packet.
+int getOpusPacketSampleCount(Uint8List packet) {
+  if (packet.isEmpty) {
+    throw Exception('Encountered empty Opus packet');
+  }
+
+  final int toc = packet[0];
+  final int config = toc >> 3;
+  final int frameCountCode = toc & 0x03;
+
+  int framesPerPacket = 0;
+  switch (frameCountCode) {
+    case 0:
+      framesPerPacket = 1;
+    case 1:
+    case 2:
+      framesPerPacket = 2;
+    case 3:
+      if (packet.length < 2) {
+        throw Exception('Malformed Opus packet with code 3 and no frame count');
+      }
+      framesPerPacket = packet[1] & 0x3F;
+      if (framesPerPacket == 0) {
+        throw Exception('Malformed Opus packet with zero frames');
+      }
+    default:
+      throw Exception('Malformed Opus packet with invalid frame count code');
+  }
+
+  late final int samplesPerFrame;
+  if (config >= 16) {
+    samplesPerFrame = <int>[120, 240, 480, 960][config & 0x03];
+  } else if (config >= 12) {
+    samplesPerFrame = <int>[480, 960][config & 0x01];
+  } else {
+    samplesPerFrame = <int>[480, 960, 1920, 2880][config & 0x03];
+  }
+
+  return samplesPerFrame * framesPerPacket;
+}
+
 /// Enum representing possible errors that can occur while reading an Ogg file.
 enum OggReaderError {
   nilStream,
@@ -45,8 +89,10 @@ class OggPageResult {
 class OpusData {
   OpusData(
       {required this.audioData,
-      required this.trailingData,
-      required this.frameSize});
+       required this.trailingData,
+       required this.frameSize,
+       required this.totalSamples,
+       required this.finalGranulePosition});
 
   /// List of audio data bytes.
   final Uint8List audioData;
@@ -56,6 +102,12 @@ class OpusData {
 
   /// Size of the audio frame.
   final int frameSize;
+
+  /// Total decoded samples represented by all packets in the file.
+  final int totalSamples;
+
+  /// Final granule position from the last audio page with completed packets.
+  final int finalGranulePosition;
 }
 
 /// Class representing the header data from the Ogg file.
@@ -199,10 +251,12 @@ class OggReader {
 
   /// Reads Opus data from the Ogg file.
   /// Throws an exception if an error occurs while reading the Opus data.
-  Future<OpusData> readOpusData({required int sampleRate}) async {
+  Future<OpusData> readOpusData() async {
     final List<int> audioData = <int>[];
     int frameSize = 0;
     final List<int> trailingData = <int>[];
+    int totalSamples = 0;
+    int finalGranulePosition = 0;
 
     while (true) {
       final OggPageResult result = await parseNextPage();
@@ -226,33 +280,29 @@ class OggReader {
       for (final Uint8List segment in segments) {
         trailingData.add(segment.length);
         audioData.addAll(segment);
+        final int packetSampleCount = getOpusPacketSampleCount(segment);
+        frameSize = frameSize == 0 ? packetSampleCount : frameSize;
+        totalSamples += packetSampleCount;
       }
 
-      if (header?.index == 2) {
-        final Uint8List tmpPacket = segments[0];
-        if (tmpPacket.isNotEmpty) {
-          final int tmptoc = tmpPacket[0] & 255;
-          final int tocConfig = tmptoc >> 3;
-          final int frameCode = tocConfig & 0x03;
-
-          if (tocConfig < 12) {
-            // SILK mode
-            frameSize = <int>[10, 20, 40, 60][frameCode] * sampleRate ~/ 1000;
-          } else if (tocConfig < 16) {
-            // Hybrid mode
-            frameSize = <int>[10, 20, 40, 60][frameCode] * sampleRate ~/ 1000;
-          } else {
-            // CELT mode
-            frameSize = <num>[2.5, 5, 10, 20][frameCode] * sampleRate ~/ 1000;
-          }
-        }
+      if (header != null &&
+          header.granulePosition != 0xFFFFFFFFFFFFFFFF &&
+          segments.isNotEmpty) {
+        finalGranulePosition = header.granulePosition;
       }
+    }
+
+    if (frameSize == 0 && trailingData.isNotEmpty) {
+      frameSize = getOpusPacketSampleCount(Uint8List.fromList(
+          audioData.sublist(0, trailingData.first)));
     }
 
     return OpusData(
         audioData: Uint8List.fromList(audioData),
         trailingData: Uint8List.fromList(trailingData),
-        frameSize: frameSize);
+        frameSize: frameSize,
+        totalSamples: totalSamples,
+        finalGranulePosition: finalGranulePosition);
   }
 
   /// Parses the next page in the Ogg file.

--- a/lib/models/ogg_models.dart
+++ b/lib/models/ogg_models.dart
@@ -89,16 +89,20 @@ class OggPageResult {
 class OpusData {
   OpusData(
       {required this.audioData,
-       required this.trailingData,
-       required this.frameSize,
-       required this.totalSamples,
-       required this.finalGranulePosition});
+      required this.trailingData,
+      required this.packetSampleCounts,
+      required this.frameSize,
+      required this.totalSamples,
+      required this.finalGranulePosition});
 
   /// List of audio data bytes.
   final Uint8List audioData;
 
   /// List of trailing data bytes.
   final Uint8List trailingData;
+
+  /// The number of decoded PCM samples contributed by each packet.
+  final List<int> packetSampleCounts;
 
   /// Size of the audio frame.
   final int frameSize;
@@ -253,8 +257,8 @@ class OggReader {
   /// Throws an exception if an error occurs while reading the Opus data.
   Future<OpusData> readOpusData() async {
     final List<int> audioData = <int>[];
-    int frameSize = 0;
     final List<int> trailingData = <int>[];
+    final List<int> packetSampleCounts = <int>[];
     int totalSamples = 0;
     int finalGranulePosition = 0;
 
@@ -281,7 +285,7 @@ class OggReader {
         trailingData.add(segment.length);
         audioData.addAll(segment);
         final int packetSampleCount = getOpusPacketSampleCount(segment);
-        frameSize = frameSize == 0 ? packetSampleCount : frameSize;
+        packetSampleCounts.add(packetSampleCount);
         totalSamples += packetSampleCount;
       }
 
@@ -292,14 +296,21 @@ class OggReader {
       }
     }
 
-    if (frameSize == 0 && trailingData.isNotEmpty) {
-      frameSize = getOpusPacketSampleCount(Uint8List.fromList(
-          audioData.sublist(0, trailingData.first)));
+    int frameSize = 0;
+    if (packetSampleCounts.isNotEmpty) {
+      frameSize = packetSampleCounts.first;
+      for (final int packetSampleCount in packetSampleCounts.skip(1)) {
+        if (packetSampleCount != frameSize) {
+          frameSize = 0;
+          break;
+        }
+      }
     }
 
     return OpusData(
         audioData: Uint8List.fromList(audioData),
         trailingData: Uint8List.fromList(trailingData),
+        packetSampleCounts: packetSampleCounts,
         frameSize: frameSize,
         totalSamples: totalSamples,
         finalGranulePosition: finalGranulePosition);

--- a/lib/ogg_caf_converter.dart
+++ b/lib/ogg_caf_converter.dart
@@ -68,7 +68,9 @@ class OggCafConverter {
       final CafFile cf = _buildCafFile(
         header: header,
         audioData: opusData.audioData,
-        trailingData: opusData.trailingData,
+        packetSizes: opusData.trailingData,
+        packetFrames:
+            opusData.frameSize == 0 ? opusData.packetSampleCounts : <int>[],
         frameSize: opusData.frameSize,
         validFrames: opusData.finalGranulePosition - header.preSkip,
         primingFrames: header.preSkip,
@@ -150,9 +152,10 @@ class OggCafConverter {
     try {
       final CafReader caf = CafReader(inputFile);
       final Uint8List bytes = await File(inputFile).readAsBytes();
-      final Uint8List audioData = caf.readAudioData(bytes);
-      final PacketTable packetTable = caf.readPacketTable(bytes);
       final AudioFormat audioFormat = caf.readAudioFormat(bytes);
+      final Uint8List audioData = caf.readAudioData(bytes);
+      final PacketTable packetTable =
+          caf.readPacketTable(bytes, audioFormat: audioFormat);
 
       // Log lengths for debugging
       log('Audio data length: ${audioData.length}');
@@ -443,41 +446,30 @@ class OggCafConverter {
   });
 
   /// Calculates the length of the packet table based on trailing data.
-  int _calculatePacketTableLength(Uint8List trailingData) {
-    int packetTableLength = 24;
-
-    for (final int value in trailingData) {
-      int numBytes = 0;
-      if ((value & 0x7f) == value) {
-        numBytes = 1;
-      } else if ((value & 0x3fff) == value) {
-        numBytes = 2;
-      } else if ((value & 0x1fffff) == value) {
-        numBytes = 3;
-      } else if ((value & 0x0fffffff) == value) {
-        numBytes = 4;
-      } else {
-        numBytes = 5;
-      }
-      packetTableLength += numBytes;
-    }
-    return packetTableLength;
-  }
-
   /// Builds a CAF file from provided data.
   CafFile _buildCafFile({
     required OggHeader header,
     required Uint8List audioData,
-    required Uint8List trailingData,
+    required Uint8List packetSizes,
+    required List<int> packetFrames,
     required int frameSize,
     required int validFrames,
     required int primingFrames,
     required int remainderFrames,
   }) {
     final int lenAudio = audioData.length;
-    final int packets = trailingData.length;
-
-    final int packetTableLength = _calculatePacketTableLength(trailingData);
+    final int packets = packetSizes.length;
+    final PacketTable packetTable = PacketTable(
+      header: PacketTableHeader(
+        numberPackets: packets,
+        numberValidFrames: validFrames,
+        primingFrames: primingFrames,
+        remainderFrames: remainderFrames,
+      ),
+      entries: packetSizes.toList(),
+      frameEntries: packetFrames,
+    );
+    final int packetTableLength = packetTable.encode().length;
 
     log('frameSize: $frameSize packetTableLength: $packetTableLength validFrames: $validFrames primingFrames: $primingFrames remainderFrames: $remainderFrames packets: $packets lenAudio: $lenAudio');
 
@@ -542,15 +534,7 @@ class OggCafConverter {
     final Chunk c4 = Chunk(
       header: ChunkHeader(
           chunkType: ChunkTypes.packetTable, chunkSize: packetTableLength),
-      contents: PacketTable(
-        header: PacketTableHeader(
-          numberPackets: packets,
-          numberValidFrames: validFrames,
-          primingFrames: primingFrames,
-          remainderFrames: remainderFrames,
-        ),
-        entries: trailingData,
-      ),
+      contents: packetTable,
     );
 
     cf.chunks.add(c4);
@@ -615,7 +599,7 @@ class CafReader {
   }
 
   /// Reads the packet table from the CAF file.
-  PacketTable readPacketTable(Uint8List bytes) {
+  PacketTable readPacketTable(Uint8List bytes, {AudioFormat? audioFormat}) {
     int offset = 8;
 
     while (offset < bytes.length) {
@@ -643,8 +627,13 @@ class CafReader {
         final int remainderFrames =
             ByteData.sublistView(Uint8List.fromList(packetTableBytes), 20, 24)
                 .getUint32(0);
-        final List<int> entries = _decodePacketTableEntries(
-            packetTableBytes.sublist(24), numberPackets);
+        final _DecodedPacketTableEntries decodedEntries =
+            _decodePacketTableEntries(
+          packetTableBytes.sublist(24),
+          numberPackets,
+          audioFormat: audioFormat,
+          bytes: bytes,
+        );
 
         log('Pakt numberPackets: $numberPackets numberValidFrames: $numberValidFrames primingFrames: $primingFrames remainderFrames: $remainderFrames');
 
@@ -657,7 +646,11 @@ class CafReader {
 
         log('Packet table chunk found at offset $offset with size $chunkSize');
 
-        return PacketTable(header: header, entries: entries);
+        return PacketTable(
+          header: header,
+          entries: decodedEntries.entries,
+          frameEntries: decodedEntries.frameEntries,
+        );
       }
 
       // Move to the next chunk
@@ -667,27 +660,70 @@ class CafReader {
     throw Exception('Packet table chunk not found');
   }
 
-  List<int> _decodePacketTableEntries(Uint8List entryBytes, int packetCount) {
+  _DecodedPacketTableEntries _decodePacketTableEntries(
+    Uint8List entryBytes,
+    int packetCount, {
+    AudioFormat? audioFormat,
+    required Uint8List bytes,
+  }) {
     if (packetCount == 0) {
-      return <int>[];
+      return const _DecodedPacketTableEntries(
+        entries: <int>[],
+        frameEntries: <int>[],
+      );
+    }
+
+    final AudioFormat resolvedAudioFormat =
+        audioFormat ?? readAudioFormat(bytes);
+    final bool variablePacketSizes = resolvedAudioFormat.bytesPerPacket == 0;
+    final bool variablePacketFrames = resolvedAudioFormat.framesPerPacket == 0;
+
+    if (!variablePacketSizes && !variablePacketFrames) {
+      return const _DecodedPacketTableEntries(
+        entries: <int>[],
+        frameEntries: <int>[],
+      );
     }
 
     final List<int> entries = <int>[];
-    int value = 0;
+    final List<int> frameEntries = <int>[];
+    int offset = 0;
 
-    for (final int byte in entryBytes) {
-      value = (value << 7) | (byte & 0x7F);
-      if ((byte & 0x80) == 0) {
+    for (int i = 0; i < packetCount; i++) {
+      if (variablePacketSizes) {
+        final (int value, int nextOffset) =
+            _decodeNextPacketTableEntry(entryBytes, offset);
         entries.add(value);
-        if (entries.length == packetCount) {
-          return entries;
-        }
-        value = 0;
+        offset = nextOffset;
+      }
+      if (variablePacketFrames) {
+        final (int value, int nextOffset) =
+            _decodeNextPacketTableEntry(entryBytes, offset);
+        frameEntries.add(value);
+        offset = nextOffset;
       }
     }
 
-    throw Exception(
-        'Packet table did not contain $packetCount complete varint entries');
+    return _DecodedPacketTableEntries(
+      entries: entries,
+      frameEntries: frameEntries,
+    );
+  }
+
+  (int, int) _decodeNextPacketTableEntry(Uint8List entryBytes, int offset) {
+    int value = 0;
+    int currentOffset = offset;
+
+    while (currentOffset < entryBytes.length) {
+      final int byte = entryBytes[currentOffset];
+      value = (value << 7) | (byte & 0x7F);
+      currentOffset++;
+      if ((byte & 0x80) == 0) {
+        return (value, currentOffset);
+      }
+    }
+
+    throw Exception('Packet table ended before a complete varint entry');
   }
 
   /// Reads the audio format from the CAF file.
@@ -749,6 +785,16 @@ class CafReader {
 
     throw Exception('Audio format chunk not found');
   }
+}
+
+class _DecodedPacketTableEntries {
+  const _DecodedPacketTableEntries({
+    required this.entries,
+    required this.frameEntries,
+  });
+
+  final List<int> entries;
+  final List<int> frameEntries;
 }
 
 /// A class representing an OGG file.

--- a/lib/ogg_caf_converter.dart
+++ b/lib/ogg_caf_converter.dart
@@ -61,8 +61,7 @@ class OggCafConverter {
     try {
       ogg = OggReader(inputFile);
       final OggHeader header = await ogg.readHeaders();
-      final OpusData opusData =
-          await ogg.readOpusData(sampleRate: header.sampleRate);
+      final OpusData opusData = await ogg.readOpusData();
 
       log('frameSize: ${opusData.frameSize}');
 
@@ -71,6 +70,9 @@ class OggCafConverter {
         audioData: opusData.audioData,
         trailingData: opusData.trailingData,
         frameSize: opusData.frameSize,
+        validFrames: opusData.finalGranulePosition - header.preSkip,
+        primingFrames: header.preSkip,
+        remainderFrames: opusData.totalSamples - opusData.finalGranulePosition,
       );
 
       return cf.encode();
@@ -160,10 +162,17 @@ class OggCafConverter {
         audioData: audioData,
         packetTable: packetTable.entries,
         channels: audioFormat.channelsPerPacket,
-        preSkip: audioFormat.framesPerPacket,
+        preSkip: _scaleFrameCountToOpusSamples(
+          frameCount: packetTable.header.primingFrames,
+          sampleRate: audioFormat.sampleRate.toInt(),
+        ),
         sampleRate: audioFormat.sampleRate.toInt(),
         version: 1,
         frameSize: audioFormat.framesPerPacket,
+        remainderFrames: _scaleFrameCountToOpusSamples(
+          frameCount: packetTable.header.remainderFrames,
+          sampleRate: audioFormat.sampleRate.toInt(),
+        ),
         repackage: false,
       );
 
@@ -191,12 +200,13 @@ class OggCafConverter {
   /// Builds an OGG file from provided data.
   OggFile buildOggFile({
     required Uint8List audioData,
-    required Uint8List packetTable,
+    required List<int> packetTable,
     required int channels,
     required int preSkip,
     required int sampleRate,
     required int version,
     required int frameSize,
+    int remainderFrames = 0,
     required bool repackage,
   }) {
     final OggFile oggFile = OggFile(pages: <OggPage>[]);
@@ -205,7 +215,8 @@ class OggCafConverter {
     int pageSequenceNumber = 0;
     final int serialNumber = DateTime.now().millisecondsSinceEpoch &
         0xFFFFFFFF; // Unique serial number
-    int headerType = 0x02; // Begin of stream
+    bool pageStartsWithContinuation = false;
+    bool currentPageHasCompletedPacket = false;
 
     // Helper function to create a page header
     Uint8List createPageHeader({
@@ -233,7 +244,8 @@ class OggCafConverter {
       final Uint8List page = Uint8List.fromList(header + body);
       int crc = 0;
       for (final int byte in page) {
-        crc = (crc << 8) ^ _crcLookupTable[((crc >> 24) & 0xFF) ^ byte];
+        crc = ((crc << 8) & 0xFFFFFFFF) ^
+            _crcLookupTable[((crc >> 24) & 0xFF) ^ byte];
       }
       return crc & 0xFFFFFFFF;
     }
@@ -242,7 +254,7 @@ class OggCafConverter {
     Uint8List createOpusHeadPacket() {
       final List<int> packet = <int>[];
       packet.addAll(utf8.encode('OpusHead')); // Signature
-      packet.add(1); // Version
+      packet.add(version); // Version
       packet.add(channels); // Channels
       packet.addAll(_encodeUint16(preSkip)); // Pre-skip
       packet.addAll(_encodeUint32(sampleRate)); // Sample rate
@@ -303,10 +315,41 @@ class OggCafConverter {
     const int maxOggSegmentSize = 255;
     List<int> currentSegment = <int>[];
     List<int> currentSegmentsTable = <int>[];
-    headerType = 0x01; // continuation flag set for the first audio page
+
+    int currentPageGranulePosition() {
+      if (!currentPageHasCompletedPacket && pageStartsWithContinuation) {
+        return 0xFFFFFFFFFFFFFFFF;
+      }
+      return granulePosition;
+    }
+
+    void flushAudioPage({
+      required int granulePosition,
+      required bool endOfStream,
+    }) {
+      final int headerType =
+          (pageStartsWithContinuation ? 0x01 : 0x00) | (endOfStream ? 0x04 : 0);
+      header = createPageHeader(
+        granulePosition: granulePosition,
+        serialNumber: serialNumber,
+        pageSequenceNumber: pageSequenceNumber,
+        segments: Uint8List.fromList(currentSegmentsTable),
+        headerType: headerType,
+      );
+      crc = calculateChecksum(header, Uint8List.fromList(currentSegment));
+      header.setRange(22, 26, _encodeUint32(crc));
+      oggFile.pages.add(
+          OggPage(header: header, body: Uint8List.fromList(currentSegment)));
+      pageSequenceNumber++;
+      currentSegment = <int>[];
+      currentSegmentsTable = <int>[];
+      currentPageHasCompletedPacket = false;
+      pageStartsWithContinuation = false;
+    }
 
     for (final Uint8List packet in packets) {
       final int packetSize = packet.length;
+      final int packetSampleCount = getOpusPacketSampleCount(packet);
       final int segmentCount =
           (packetSize + maxOggSegmentSize - 1) ~/ maxOggSegmentSize;
 
@@ -320,25 +363,11 @@ class OggCafConverter {
         // (Optional boundary check — you may handle partial flush if needed.)
         if (currentSegmentsTable.length == 255 ||
             currentSegment.length + segmentSize > 65025) {
-          // Create and finalize the current page
-          header = createPageHeader(
-            granulePosition: granulePosition,
-            serialNumber: serialNumber,
-            pageSequenceNumber: pageSequenceNumber,
-            segments: Uint8List.fromList(currentSegmentsTable),
-            headerType: headerType,
+          flushAudioPage(
+            granulePosition: currentPageGranulePosition(),
+            endOfStream: false,
           );
-          crc = calculateChecksum(header, Uint8List.fromList(currentSegment));
-          header.setRange(22, 26, _encodeUint32(crc));
-          oggFile.pages.add(OggPage(
-              header: header, body: Uint8List.fromList(currentSegment)));
-          pageSequenceNumber++;
-
-          // Reset for the next page
-          currentSegment = <int>[];
-          currentSegmentsTable = <int>[];
-          // After the first audio page, normal pages won't have the "fresh" (0x02) bit
-          headerType = 0x00;
+          pageStartsWithContinuation = true;
         }
 
         // Append this segment of data
@@ -346,32 +375,30 @@ class OggCafConverter {
         currentSegmentsTable.add(segmentSize);
       }
 
-      // Update granule position (this is a simplistic approach)
-      if (repackage) {
-        granulePosition += frameSize;
-      } else {
-        // For example, if sampleRate=48000, frameSize is typically the number
-        // of samples in an Opus frame at 48 kHz, so we scale if needed.
-        granulePosition += frameSize * (48000 ~/ sampleRate);
-      }
+      granulePosition += packetSampleCount;
+      currentPageHasCompletedPacket = true;
     }
 
     // Flush the last page (end of stream)
     if (currentSegment.isNotEmpty) {
-      header = createPageHeader(
-        granulePosition: granulePosition,
-        serialNumber: serialNumber,
-        pageSequenceNumber: pageSequenceNumber,
-        segments: Uint8List.fromList(currentSegmentsTable),
-        headerType: 0x04, // End of stream
+      flushAudioPage(
+        granulePosition: granulePosition - remainderFrames,
+        endOfStream: true,
       );
-      crc = calculateChecksum(header, Uint8List.fromList(currentSegment));
-      header.setRange(22, 26, _encodeUint32(crc));
-      oggFile.pages.add(
-          OggPage(header: header, body: Uint8List.fromList(currentSegment)));
     }
 
     return oggFile;
+  }
+
+  int _scaleFrameCountToOpusSamples({
+    required int frameCount,
+    required int sampleRate,
+  }) {
+    if (sampleRate <= 0 || 48000 % sampleRate != 0) {
+      throw Exception('Unsupported Opus sample rate: $sampleRate');
+    }
+
+    return frameCount * (48000 ~/ sampleRate);
   }
 
   Uint8List _encodeUint64(int value) {
@@ -403,8 +430,7 @@ class OggCafConverter {
     ]);
   }
 
-  final Uint8List _crcLookupTable =
-      Uint8List.fromList(List<int>.generate(256, (int i) {
+  final List<int> _crcLookupTable = List<int>.generate(256, (int i) {
     int r = i << 24;
     for (int j = 0; j < 8; j++) {
       if (r & 0x80000000 != 0) {
@@ -414,7 +440,7 @@ class OggCafConverter {
       }
     }
     return r;
-  }));
+  });
 
   /// Calculates the length of the packet table based on trailing data.
   int _calculatePacketTableLength(Uint8List trailingData) {
@@ -444,14 +470,16 @@ class OggCafConverter {
     required Uint8List audioData,
     required Uint8List trailingData,
     required int frameSize,
+    required int validFrames,
+    required int primingFrames,
+    required int remainderFrames,
   }) {
     final int lenAudio = audioData.length;
     final int packets = trailingData.length;
-    final int frames = frameSize * packets;
 
     final int packetTableLength = _calculatePacketTableLength(trailingData);
 
-    log('frameSize: $frameSize packetTableLength: $packetTableLength frames: $frames packets: $packets lenAudio: $lenAudio');
+    log('frameSize: $frameSize packetTableLength: $packetTableLength validFrames: $validFrames primingFrames: $primingFrames remainderFrames: $remainderFrames packets: $packets lenAudio: $lenAudio');
 
     final CafFile cf = CafFile(
         fileHeader: FileHeader(
@@ -462,7 +490,7 @@ class OggCafConverter {
       header:
           ChunkHeader(chunkType: ChunkTypes.audioDescription, chunkSize: 32),
       contents: AudioFormat(
-        sampleRate: header.sampleRate.toDouble(),
+        sampleRate: opusFixedSampleRate.toDouble(),
         formatID: FourByteString('opus'),
         formatFlags: 0x00000000,
         bytesPerPacket: 0,
@@ -517,9 +545,9 @@ class OggCafConverter {
       contents: PacketTable(
         header: PacketTableHeader(
           numberPackets: packets,
-          numberValidFrames: frames,
-          primingFrames: 0,
-          remainderFrames: 0,
+          numberValidFrames: validFrames,
+          primingFrames: primingFrames,
+          remainderFrames: remainderFrames,
         ),
         entries: trailingData,
       ),
@@ -615,7 +643,8 @@ class CafReader {
         final int remainderFrames =
             ByteData.sublistView(Uint8List.fromList(packetTableBytes), 20, 24)
                 .getUint32(0);
-        final Uint8List entries = packetTableBytes.sublist(24);
+        final List<int> entries = _decodePacketTableEntries(
+            packetTableBytes.sublist(24), numberPackets);
 
         log('Pakt numberPackets: $numberPackets numberValidFrames: $numberValidFrames primingFrames: $primingFrames remainderFrames: $remainderFrames');
 
@@ -628,11 +657,6 @@ class CafReader {
 
         log('Packet table chunk found at offset $offset with size $chunkSize');
 
-        // Check for padding or extra bytes in the packet table
-        if (entries.length != numberPackets) {
-          log('Warning: Number of packets in header does not match the length of packet table entries (${entries.length} / $numberPackets)');
-        }
-
         return PacketTable(header: header, entries: entries);
       }
 
@@ -641,6 +665,29 @@ class CafReader {
     }
 
     throw Exception('Packet table chunk not found');
+  }
+
+  List<int> _decodePacketTableEntries(Uint8List entryBytes, int packetCount) {
+    if (packetCount == 0) {
+      return <int>[];
+    }
+
+    final List<int> entries = <int>[];
+    int value = 0;
+
+    for (final int byte in entryBytes) {
+      value = (value << 7) | (byte & 0x7F);
+      if ((byte & 0x80) == 0) {
+        entries.add(value);
+        if (entries.length == packetCount) {
+          return entries;
+        }
+        value = 0;
+      }
+    }
+
+    throw Exception(
+        'Packet table did not contain $packetCount complete varint entries');
   }
 
   /// Reads the audio format from the CAF file.

--- a/test/caf_models_test.dart
+++ b/test/caf_models_test.dart
@@ -117,7 +117,7 @@ void main() {
           primingFrames: 3,
           remainderFrames: 4,
         ),
-        entries: Uint8List.fromList(<int>[5, 6, 7]),
+        entries: <int>[5, 6, 7],
       );
       final Uint8List encoded = packetTable.encode();
       expect(ByteData.sublistView(encoded).getInt64(0), equals(1));
@@ -125,6 +125,20 @@ void main() {
       expect(ByteData.sublistView(encoded).getInt32(16), equals(3));
       expect(ByteData.sublistView(encoded).getInt32(20), equals(4));
       expect(encoded.sublist(24), equals(<int>[5, 6, 7]));
+    });
+
+    test('encodes large packet sizes as varints', () {
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 3,
+          numberValidFrames: 2,
+          primingFrames: 3,
+          remainderFrames: 4,
+        ),
+        entries: <int>[5, 128, 300],
+      );
+      final Uint8List encoded = packetTable.encode();
+      expect(encoded.sublist(24), equals(<int>[5, 129, 0, 130, 44]));
     });
   });
 

--- a/test/caf_models_test.dart
+++ b/test/caf_models_test.dart
@@ -112,7 +112,7 @@ void main() {
     test('encodes PacketTable correctly', () {
       final PacketTable packetTable = PacketTable(
         header: PacketTableHeader(
-          numberPackets: 1,
+          numberPackets: 3,
           numberValidFrames: 2,
           primingFrames: 3,
           remainderFrames: 4,
@@ -120,7 +120,7 @@ void main() {
         entries: <int>[5, 6, 7],
       );
       final Uint8List encoded = packetTable.encode();
-      expect(ByteData.sublistView(encoded).getInt64(0), equals(1));
+      expect(ByteData.sublistView(encoded).getInt64(0), equals(3));
       expect(ByteData.sublistView(encoded).getInt64(8), equals(2));
       expect(ByteData.sublistView(encoded).getInt32(16), equals(3));
       expect(ByteData.sublistView(encoded).getInt32(20), equals(4));
@@ -139,6 +139,37 @@ void main() {
       );
       final Uint8List encoded = packetTable.encode();
       expect(encoded.sublist(24), equals(<int>[5, 129, 0, 130, 44]));
+    });
+
+    test('encodes packet size and frame-count pairs as varints', () {
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 2,
+          numberValidFrames: 1440,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: <int>[5, 128],
+        frameEntries: <int>[480, 960],
+      );
+      final Uint8List encoded = packetTable.encode();
+      expect(encoded.sublist(24), equals(<int>[5, 131, 96, 129, 0, 135, 64]));
+    });
+
+    test('encodes large packet size and frame-count pairs as varints', () {
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 2,
+          numberValidFrames: 17344,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: <int>[300, 128],
+        frameEntries: <int>[16384, 960],
+      );
+      final Uint8List encoded = packetTable.encode();
+      expect(encoded.sublist(24),
+          equals(<int>[130, 44, 129, 128, 0, 129, 0, 135, 64]));
     });
   });
 

--- a/test/ogg_caf_converter_test.dart
+++ b/test/ogg_caf_converter_test.dart
@@ -53,9 +53,10 @@ Future<(AudioFormat, PacketTable, Uint8List)> _readCafContents(
     String path) async {
   final CafReader reader = CafReader(path);
   final Uint8List bytes = await File(path).readAsBytes();
+  final AudioFormat audioFormat = reader.readAudioFormat(bytes);
   return (
-    reader.readAudioFormat(bytes),
-    reader.readPacketTable(bytes),
+    audioFormat,
+    reader.readPacketTable(bytes, audioFormat: audioFormat),
     reader.readAudioData(bytes),
   );
 }
@@ -104,10 +105,35 @@ Iterable<Uint8List> _iterateOggPages(Uint8List bytes) sync* {
   }
 }
 
-Uint8List _buildSyntheticOpusPacket(int length) {
+Uint8List _buildSyntheticOpusPacket(int length, {int toc = 0x80}) {
   final Uint8List packet = Uint8List(length);
-  packet[0] = 0x80;
+  packet[0] = toc;
   return packet;
+}
+
+OggFile _buildVariableDurationSyntheticOgg({
+  int preSkip = 0,
+  int remainderFrames = 0,
+}) {
+  final OggCafConverter syntheticConverter = OggCafConverter();
+  final List<Uint8List> packets = <Uint8List>[
+    _buildSyntheticOpusPacket(1, toc: 0x90),
+    _buildSyntheticOpusPacket(1, toc: 0x98),
+    _buildSyntheticOpusPacket(1, toc: 0x90),
+  ];
+  return syntheticConverter.buildOggFile(
+    audioData: Uint8List.fromList(
+      packets.expand((Uint8List packet) => packet).toList(),
+    ),
+    packetTable: packets.map((Uint8List packet) => packet.length).toList(),
+    channels: 1,
+    preSkip: preSkip,
+    sampleRate: opusFixedSampleRate,
+    version: 1,
+    frameSize: 0,
+    remainderFrames: remainderFrames,
+    repackage: false,
+  );
 }
 
 void main() {
@@ -197,6 +223,84 @@ void main() {
             equals(refTable.header.primingFrames));
         expect(libTable.header.remainderFrames,
             equals(refTable.header.remainderFrames));
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('writes packet frame entries for variable-duration OGG input',
+        () async {
+      final OggFile ogg = _buildVariableDurationSyntheticOgg();
+
+      final Directory tempDir =
+          await Directory.systemTemp.createTemp('ogg-caf-variable-frames-');
+      final String inputFile = '${tempDir.path}/input.ogg';
+      final String outputFile = '${tempDir.path}/output.caf';
+      final String roundTripFile = '${tempDir.path}/roundtrip.ogg';
+
+      try {
+        await File(inputFile).writeAsBytes(ogg.encode());
+
+        await oggCafConverter.convertOggToCaf(
+          input: inputFile,
+          output: outputFile,
+        );
+
+        final (AudioFormat audioFormat, PacketTable packetTable, _) =
+            await _readCafContents(outputFile);
+
+        expect(audioFormat.sampleRate, equals(48000));
+        expect(audioFormat.bytesPerPacket, equals(0));
+        expect(audioFormat.framesPerPacket, equals(0));
+        expect(packetTable.entries, equals(<int>[1, 1, 1]));
+        expect(packetTable.frameEntries, equals(<int>[480, 960, 480]));
+        expect(packetTable.header.numberValidFrames, equals(1920));
+
+        await oggCafConverter.convertCafToOgg(
+          input: outputFile,
+          output: roundTripFile,
+        );
+
+        final List<Uint8List> originalPackets =
+            await _readOggAudioPackets(inputFile);
+        final List<Uint8List> roundTripPackets =
+            await _readOggAudioPackets(roundTripFile);
+        expect(roundTripPackets, equals(originalPackets));
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('preserves trim metadata for variable-duration OGG input', () async {
+      final OggFile ogg = _buildVariableDurationSyntheticOgg(
+        preSkip: 120,
+        remainderFrames: 240,
+      );
+      final Directory tempDir =
+          await Directory.systemTemp.createTemp('ogg-caf-variable-trim-');
+      final String inputFile = '${tempDir.path}/input.ogg';
+      final String outputFile = '${tempDir.path}/output.caf';
+
+      try {
+        await File(inputFile).writeAsBytes(ogg.encode());
+
+        await oggCafConverter.convertOggToCaf(
+          input: inputFile,
+          output: outputFile,
+        );
+
+        final (AudioFormat audioFormat, PacketTable packetTable, _) =
+            await _readCafContents(outputFile);
+
+        expect(audioFormat.framesPerPacket, equals(0));
+        expect(packetTable.frameEntries, equals(<int>[480, 960, 480]));
+        expect(packetTable.header.primingFrames, equals(120));
+        expect(packetTable.header.remainderFrames, equals(240));
+        expect(packetTable.header.numberValidFrames, equals(1560));
       } finally {
         if (tempDir.existsSync()) {
           tempDir.deleteSync(recursive: true);
@@ -549,6 +653,172 @@ void main() {
 
       expect(decoded.header.numberPackets, equals(0));
       expect(decoded.entries, isEmpty);
+    });
+
+    test('reads packet size and frame-count pairs when frames vary', () {
+      final AudioFormat audioFormat = AudioFormat(
+        sampleRate: 48000,
+        formatID: FourByteString('opus'),
+        formatFlags: 0,
+        bytesPerPacket: 0,
+        framesPerPacket: 0,
+        channelsPerPacket: 1,
+        bitsPerChannel: 0,
+      );
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 2,
+          numberValidFrames: 1440,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: <int>[5, 128],
+        frameEntries: <int>[480, 960],
+      );
+      final CafFile cafFile = CafFile(
+        fileHeader: FileHeader(
+          fileType: FourByteString('caff'),
+          fileVersion: 1,
+          fileFlags: 0,
+        ),
+        chunks: <Chunk>[
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.audioDescription,
+              chunkSize: 32,
+            ),
+            contents: audioFormat,
+          ),
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.packetTable,
+              chunkSize: packetTable.encode().length,
+            ),
+            contents: packetTable,
+          ),
+        ],
+      );
+
+      final Uint8List bytes = cafFile.encode();
+      final PacketTable decoded = CafReader('unused').readPacketTable(bytes);
+
+      expect(decoded.entries, equals(packetTable.entries));
+      expect(decoded.frameEntries, equals(packetTable.frameEntries));
+    });
+
+    test('reads frame-count-only packet tables when packet sizes are constant',
+        () {
+      final AudioFormat audioFormat = AudioFormat(
+        sampleRate: 48000,
+        formatID: FourByteString('opus'),
+        formatFlags: 0,
+        bytesPerPacket: 3,
+        framesPerPacket: 0,
+        channelsPerPacket: 1,
+        bitsPerChannel: 0,
+      );
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 2,
+          numberValidFrames: 1440,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: const <int>[],
+        frameEntries: <int>[480, 960],
+      );
+      final CafFile cafFile = CafFile(
+        fileHeader: FileHeader(
+          fileType: FourByteString('caff'),
+          fileVersion: 1,
+          fileFlags: 0,
+        ),
+        chunks: <Chunk>[
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.audioDescription,
+              chunkSize: 32,
+            ),
+            contents: audioFormat,
+          ),
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.packetTable,
+              chunkSize: packetTable.encode().length,
+            ),
+            contents: packetTable,
+          ),
+        ],
+      );
+
+      final Uint8List bytes = cafFile.encode();
+      final PacketTable decoded = CafReader('unused').readPacketTable(bytes);
+
+      expect(decoded.entries, isEmpty);
+      expect(decoded.frameEntries, equals(packetTable.frameEntries));
+    });
+
+    test('throws for malformed packet size and frame-count pairs', () {
+      final AudioFormat audioFormat = AudioFormat(
+        sampleRate: 48000,
+        formatID: FourByteString('opus'),
+        formatFlags: 0,
+        bytesPerPacket: 0,
+        framesPerPacket: 0,
+        channelsPerPacket: 1,
+        bitsPerChannel: 0,
+      );
+      final Uint8List validPacketTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 2,
+          numberValidFrames: 1440,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: <int>[5, 128],
+        frameEntries: <int>[480, 960],
+      ).encode();
+      final CafFile cafFile = CafFile(
+        fileHeader: FileHeader(
+          fileType: FourByteString('caff'),
+          fileVersion: 1,
+          fileFlags: 0,
+        ),
+        chunks: <Chunk>[
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.audioDescription,
+              chunkSize: 32,
+            ),
+            contents: audioFormat,
+          ),
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.packetTable,
+              chunkSize: validPacketTable.length,
+            ),
+            contents: PacketTable(
+              header: PacketTableHeader(
+                numberPackets: 2,
+                numberValidFrames: 1440,
+                primingFrames: 0,
+                remainderFrames: 0,
+              ),
+              entries: <int>[5, 128],
+              frameEntries: <int>[480, 960],
+            ),
+          ),
+        ],
+      );
+      final Uint8List bytes = cafFile.encode();
+      final Uint8List malformedBytes = bytes.sublist(0, bytes.length - 1);
+      ByteData.sublistView(malformedBytes, 56, 64)
+          .setInt64(0, validPacketTable.length - 1);
+
+      expect(
+        () => CafReader('unused').readPacketTable(malformedBytes),
+        throwsException,
+      );
     });
   });
 }

--- a/test/ogg_caf_converter_test.dart
+++ b/test/ogg_caf_converter_test.dart
@@ -178,9 +178,11 @@ void main() {
       final String? afconvertPath = await _findExecutable('afconvert');
       if (afconvertPath == null) {
         markTestSkipped('afconvert is not available');
+        return;
       }
-      if (!await _afconvertSupportsOpus(afconvertPath!)) {
+      if (!await _afconvertSupportsOpus(afconvertPath)) {
         markTestSkipped('afconvert does not support Opus on this machine');
+        return;
       }
 
       final Directory tempDir =
@@ -472,6 +474,7 @@ void main() {
       final String? ffmpegPath = await _findExecutable('ffmpeg');
       if (ffmpegPath == null) {
         markTestSkipped('ffmpeg is not available');
+        return;
       }
 
       final Directory tempDir =
@@ -481,7 +484,7 @@ void main() {
 
       try {
         final ProcessResult ffmpegRemux =
-            await Process.run(ffmpegPath!, <String>[
+            await Process.run(ffmpegPath, <String>[
           '-v',
           'error',
           '-i',

--- a/test/ogg_caf_converter_test.dart
+++ b/test/ogg_caf_converter_test.dart
@@ -1,8 +1,114 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:ogg_caf_converter/models/caf_models.dart';
+import 'package:ogg_caf_converter/models/ogg_models.dart';
 import 'package:ogg_caf_converter/ogg_caf_converter.dart';
 import 'package:test/test.dart';
+
+Future<String?> _findExecutable(String name) async {
+  final ProcessResult result = await Process.run('which', <String>[name]);
+  if (result.exitCode != 0) {
+    return null;
+  }
+
+  final String path = (result.stdout as String).trim();
+  return path.isEmpty ? null : path;
+}
+
+Future<bool> _afconvertSupportsOpus(String path) async {
+  final ProcessResult result = await Process.run(path, <String>['-hf']);
+  final String formats =
+      '${result.stdout as String}\n${result.stderr as String}';
+  return formats.contains("'Oggf'") &&
+      formats.contains("'caff'") &&
+      formats.contains("'opus'");
+}
+
+Future<List<Uint8List>> _readOggAudioPackets(String path) async {
+  final OggReader reader = OggReader(path);
+  final List<Uint8List> packets = <Uint8List>[];
+  await reader.readHeaders();
+
+  while (true) {
+    final OggPageResult page = await reader.parseNextPage();
+    if (page.error != null) {
+      break;
+    }
+
+    if (page.segments.isNotEmpty &&
+        String.fromCharCodes(page.segments.first.take(8).toList()) ==
+            'OpusTags') {
+      continue;
+    }
+
+    packets.addAll(page.segments);
+  }
+
+  await reader.close();
+  return packets;
+}
+
+Future<(AudioFormat, PacketTable, Uint8List)> _readCafContents(
+    String path) async {
+  final CafReader reader = CafReader(path);
+  final Uint8List bytes = await File(path).readAsBytes();
+  return (
+    reader.readAudioFormat(bytes),
+    reader.readPacketTable(bytes),
+    reader.readAudioData(bytes),
+  );
+}
+
+final List<int> _oggCrcLookupTable = List<int>.generate(256, (int i) {
+  int r = i << 24;
+  for (int j = 0; j < 8; j++) {
+    if ((r & 0x80000000) != 0) {
+      r = ((r << 1) ^ 0x04C11DB7) & 0xFFFFFFFF;
+    } else {
+      r = (r << 1) & 0xFFFFFFFF;
+    }
+  }
+  return r;
+});
+
+int _computeOggPageCrc(Uint8List page) {
+  final Uint8List copy = Uint8List.fromList(page);
+  copy.setRange(22, 26, <int>[0, 0, 0, 0]);
+
+  int crc = 0;
+  for (final int byte in copy) {
+    crc = ((crc << 8) & 0xFFFFFFFF) ^
+        _oggCrcLookupTable[((crc >> 24) & 0xFF) ^ byte];
+  }
+  return crc & 0xFFFFFFFF;
+}
+
+Iterable<Uint8List> _iterateOggPages(Uint8List bytes) sync* {
+  int offset = 0;
+  while (offset + pageHeaderLen <= bytes.length) {
+    final int segmentCount = bytes[offset + 26];
+    final int headerLength = pageHeaderLen + segmentCount;
+    int bodyLength = 0;
+    for (int i = 0; i < segmentCount; i++) {
+      bodyLength += bytes[offset + pageHeaderLen + i];
+    }
+
+    final int pageEnd = offset + headerLength + bodyLength;
+    if (pageEnd > bytes.length) {
+      break;
+    }
+
+    yield bytes.sublist(offset, pageEnd);
+    offset = pageEnd;
+  }
+}
+
+Uint8List _buildSyntheticOpusPacket(int length) {
+  final Uint8List packet = Uint8List(length);
+  packet[0] = 0x80;
+  return packet;
+}
 
 void main() {
   group('convertOggToCaf', () {
@@ -20,6 +126,82 @@ void main() {
       expect(File(inputFile).existsSync(), isTrue);
       // Delete the output file after completing test
       File(outputFile).deleteSync();
+    });
+
+    test('preserves OGG trimming metadata in generated CAF', () async {
+      const String inputFile = 'test_resources/test.ogg';
+      const String outputFile = 'test_resources/test_output.caf';
+      await oggCafConverter.convertOggToCaf(
+          input: inputFile, output: outputFile);
+
+      final (AudioFormat audioFormat, PacketTable packetTable, Uint8List _) =
+          await _readCafContents(outputFile);
+
+      expect(audioFormat.sampleRate, equals(48000));
+      expect(audioFormat.framesPerPacket, equals(960));
+      expect(audioFormat.channelsPerPacket, equals(1));
+      expect(packetTable.header.numberPackets, equals(151));
+      expect(packetTable.header.numberValidFrames, equals(144000));
+      expect(packetTable.header.primingFrames, equals(312));
+      expect(packetTable.header.remainderFrames, equals(648));
+
+      File(outputFile).deleteSync();
+    });
+
+    test('matches afconvert output for OGG to CAF', () async {
+      final String? afconvertPath = await _findExecutable('afconvert');
+      if (afconvertPath == null) {
+        markTestSkipped('afconvert is not available');
+      }
+      if (!await _afconvertSupportsOpus(afconvertPath!)) {
+        markTestSkipped('afconvert does not support Opus on this machine');
+      }
+
+      final Directory tempDir =
+          await Directory.systemTemp.createTemp('ogg-caf-afconvert-');
+      final String libraryOutput = '${tempDir.path}/library.caf';
+      final String referenceOutput = '${tempDir.path}/reference.caf';
+
+      try {
+        await oggCafConverter.convertOggToCaf(
+          input: 'test_resources/test.ogg',
+          output: libraryOutput,
+        );
+
+        final ProcessResult afconvertResult =
+            await Process.run(afconvertPath, <String>[
+          '-f',
+          'caff',
+          '-d',
+          'opus',
+          'test_resources/test.ogg',
+          referenceOutput,
+        ]);
+        expect(afconvertResult.exitCode, equals(0),
+            reason: afconvertResult.stderr.toString());
+
+        final (AudioFormat libFormat, PacketTable libTable, _) =
+            await _readCafContents(libraryOutput);
+        final (AudioFormat refFormat, PacketTable refTable, _) =
+            await _readCafContents(referenceOutput);
+
+        expect(libFormat.sampleRate, equals(refFormat.sampleRate));
+        expect(libFormat.framesPerPacket, equals(refFormat.framesPerPacket));
+        expect(
+            libFormat.channelsPerPacket, equals(refFormat.channelsPerPacket));
+        expect(libTable.header.numberPackets,
+            equals(refTable.header.numberPackets));
+        expect(libTable.header.numberValidFrames,
+            equals(refTable.header.numberValidFrames));
+        expect(libTable.header.primingFrames,
+            equals(refTable.header.primingFrames));
+        expect(libTable.header.remainderFrames,
+            equals(refTable.header.remainderFrames));
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
     });
 
     test('deletes input file after converting OGG to CAF', () async {
@@ -61,6 +243,31 @@ void main() {
   group('convertCafToOgg', () {
     final OggCafConverter oggCafConverter = OggCafConverter();
 
+    test('marks pages that begin with a continued packet', () {
+      final List<Uint8List> packets = <Uint8List>[
+        ...List<Uint8List>.generate(254, (_) => _buildSyntheticOpusPacket(1)),
+        _buildSyntheticOpusPacket(400),
+        ...List<Uint8List>.generate(3, (_) => _buildSyntheticOpusPacket(1)),
+      ];
+
+      final OggFile ogg = oggCafConverter.buildOggFile(
+        audioData: Uint8List.fromList(
+          packets.expand((Uint8List packet) => packet).toList(),
+        ),
+        packetTable: packets.map((Uint8List packet) => packet.length).toList(),
+        channels: 1,
+        preSkip: 0,
+        sampleRate: opusFixedSampleRate,
+        version: 1,
+        frameSize: 960,
+        repackage: false,
+      );
+
+      expect(ogg.pages.length, equals(4));
+      expect(ogg.pages[2].header[5], equals(0x00));
+      expect(ogg.pages[3].header[5], equals(0x05));
+    });
+
     test('converts CAF to OGG successfully', () async {
       const String inputFile = 'test_resources/test.caf';
       const String outputFile = 'test_resources/test_output.ogg';
@@ -73,6 +280,148 @@ void main() {
       expect(File(inputFile).existsSync(), isTrue);
       // Delete the output file after completing test
       File(outputFile).deleteSync();
+    });
+
+    test('preserves CAF trimming metadata in generated OGG', () async {
+      const String inputFile = 'test_resources/test.caf';
+      const String outputFile = 'test_resources/test_output.ogg';
+      await oggCafConverter.convertCafToOgg(
+          input: inputFile, output: outputFile);
+
+      final OggReader reader = OggReader(outputFile);
+      final OggHeader headers = await reader.readHeaders();
+      expect(headers.preSkip, equals(312));
+
+      final OggPageResult tagsPage = await reader.parseNextPage();
+      expect(tagsPage.pageHeader!.headerType, equals(0));
+
+      final OggPageResult audioPage = await reader.parseNextPage();
+      expect(audioPage.pageHeader!.headerType, equals(0x04));
+      expect(audioPage.pageHeader!.granulePosition, equals(144312));
+
+      await reader.close();
+      File(outputFile).deleteSync();
+    });
+
+    test('writes valid OGG CRC checksums', () async {
+      const String inputFile = 'test_resources/test.caf';
+      const String outputFile = 'test_resources/test_output.ogg';
+      await oggCafConverter.convertCafToOgg(
+          input: inputFile, output: outputFile);
+
+      final Uint8List bytes = await File(outputFile).readAsBytes();
+      for (final Uint8List page in _iterateOggPages(bytes)) {
+        final int storedChecksum =
+            ByteData.sublistView(page, 22, 26).getUint32(0, Endian.little);
+        expect(_computeOggPageCrc(page), equals(storedChecksum));
+      }
+
+      File(outputFile).deleteSync();
+    });
+
+    test('writes internally consistent OGG page metadata', () async {
+      const String inputFile = 'test_resources/test.caf';
+      const String outputFile = 'test_resources/test_output.ogg';
+      await oggCafConverter.convertCafToOgg(
+          input: inputFile, output: outputFile);
+
+      final OggReader reader = OggReader(outputFile);
+      await reader.readHeaders();
+
+      int? serialNumber;
+      int? previousSequence;
+      int previousGranulePosition = 0;
+      OggPageHeader? lastHeader;
+
+      while (true) {
+        final OggPageResult page = await reader.parseNextPage();
+        if (page.error != null) {
+          break;
+        }
+
+        final OggPageHeader header = page.pageHeader!;
+        serialNumber ??= header.serial;
+        expect(header.serial, equals(serialNumber));
+
+        if (previousSequence != null) {
+          expect(header.index, equals(previousSequence + 1));
+        }
+        previousSequence = header.index;
+
+        if (header.granulePosition != 0xFFFFFFFFFFFFFFFF) {
+          expect(header.granulePosition,
+              greaterThanOrEqualTo(previousGranulePosition));
+          previousGranulePosition = header.granulePosition;
+        }
+
+        lastHeader = header;
+      }
+
+      expect(lastHeader, isNotNull);
+      expect((lastHeader!.headerType & 0x04) != 0, isTrue);
+
+      await reader.close();
+      File(outputFile).deleteSync();
+    });
+
+    test('matches ffmpeg packet copy output for CAF to OGG', () async {
+      final String? ffmpegPath = await _findExecutable('ffmpeg');
+      if (ffmpegPath == null) {
+        markTestSkipped('ffmpeg is not available');
+      }
+
+      final Directory tempDir =
+          await Directory.systemTemp.createTemp('ogg-caf-ffmpeg-');
+      final String ffmpegOutput = '${tempDir.path}/ffmpeg.ogg';
+      final String libraryOutput = '${tempDir.path}/library.ogg';
+
+      try {
+        final ProcessResult ffmpegRemux =
+            await Process.run(ffmpegPath!, <String>[
+          '-v',
+          'error',
+          '-i',
+          'test_resources/test.caf',
+          '-c',
+          'copy',
+          ffmpegOutput,
+        ]);
+        expect(ffmpegRemux.exitCode, equals(0),
+            reason: ffmpegRemux.stderr.toString());
+
+        await oggCafConverter.convertCafToOgg(
+          input: 'test_resources/test.caf',
+          output: libraryOutput,
+        );
+
+        final ProcessResult ffmpegDecode =
+            await Process.run(ffmpegPath, <String>[
+          '-v',
+          'error',
+          '-i',
+          libraryOutput,
+          '-f',
+          'null',
+          '-',
+        ]);
+        expect(ffmpegDecode.exitCode, equals(0),
+            reason: ffmpegDecode.stderr.toString());
+
+        final List<Uint8List> expectedPackets =
+            await _readOggAudioPackets(ffmpegOutput);
+        final List<Uint8List> actualPackets =
+            await _readOggAudioPackets(libraryOutput);
+
+        expect(actualPackets.length, equals(expectedPackets.length));
+        for (int i = 0; i < actualPackets.length; i++) {
+          expect(actualPackets[i], equals(expectedPackets[i]),
+              reason: 'Packet mismatch at index $i');
+        }
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
     });
 
     test('deletes input file after converting CAF to OGG', () async {
@@ -164,6 +513,42 @@ void main() {
         () async => oggCafConverter.convertOggToCafInMemory(input: inputFile),
         throwsA(isA<Exception>()),
       );
+    });
+  });
+
+  group('CafReader', () {
+    test('reads empty packet tables when the packet count is zero', () {
+      final PacketTable packetTable = PacketTable(
+        header: PacketTableHeader(
+          numberPackets: 0,
+          numberValidFrames: 0,
+          primingFrames: 0,
+          remainderFrames: 0,
+        ),
+        entries: const <int>[],
+      );
+      final CafFile cafFile = CafFile(
+        fileHeader: FileHeader(
+          fileType: FourByteString('caff'),
+          fileVersion: 1,
+          fileFlags: 0,
+        ),
+        chunks: <Chunk>[
+          Chunk(
+            header: ChunkHeader(
+              chunkType: ChunkTypes.packetTable,
+              chunkSize: 24,
+            ),
+            contents: packetTable,
+          ),
+        ],
+      );
+
+      final PacketTable decoded =
+          CafReader('unused').readPacketTable(cafFile.encode());
+
+      expect(decoded.header.numberPackets, equals(0));
+      expect(decoded.entries, isEmpty);
     });
   });
 }

--- a/test/ogg_models_test.dart
+++ b/test/ogg_models_test.dart
@@ -16,6 +16,7 @@ void main() {
       final OpusData opusData = await reader.readOpusData();
       expect(opusData.audioData, isNotEmpty);
       expect(opusData.frameSize, isNotNull);
+      expect(opusData.packetSampleCounts, isNotEmpty);
       await reader.close();
     });
 

--- a/test/ogg_models_test.dart
+++ b/test/ogg_models_test.dart
@@ -13,7 +13,7 @@ void main() {
 
     test('reads Opus data successfully', () async {
       final OggReader reader = OggReader('test_resources/test.ogg');
-      final OpusData opusData = await reader.readOpusData(sampleRate: 48000);
+      final OpusData opusData = await reader.readOpusData();
       expect(opusData.audioData, isNotEmpty);
       expect(opusData.frameSize, isNotNull);
       await reader.close();


### PR DESCRIPTION
This follows the metadata fix by handling a CAF shape the library still wasn’t
modeling correctly: variable-duration Opus packets.

The previous implementation worked for the bundled fixture, but it assumed one 
framesPerPacket value could describe the whole file. CAF allows packet tables that
store packet sizes, frame counts, or ordered size/frame pairs depending on whether
packet size and duration are constant.

What changed

 - extend PacketTable to represent per-packet frame counts when needed
 - expose per-packet sample counts from OggReader.readOpusData()
 - write framesPerPacket = 0 for variable-duration OGG -> CAF output
 - write and read paired pakt entries for packet size + frame count
 - keep the constant-duration path unchanged

Tests

Added regression coverage for:

 - paired packet size/frame-count varints
 - large varints in paired entries
 - frames-only packet tables
 - variable-duration OGG -> CAF output
 - variable-duration OGG -> CAF -> OGG roundtrip
 - variable-duration input with trim metadata
 - malformed paired pakt data

So this PR is mostly about making the converter correct for more valid CAF files,
not changing the working constant-duration path.